### PR TITLE
Add the --lines option to set the maximum output line

### DIFF
--- a/travis/README.md
+++ b/travis/README.md
@@ -9,7 +9,7 @@ By default, a YAML file called `.docker-build.yml` is used.
 ## Command line usage
 
 ```
-usage: docker-build [-h] [-i] [-v] [-C] [-n NAME] [-c CONFIG]
+usage: docker-build [-h] [-i] [-v] [-C] [-n NAME] [-l LINES] [-c CONFIG]
                     [-b {meson,autotools}]
 
 Compile the software in a Docker container
@@ -21,9 +21,12 @@ optional arguments:
   -C, --clean           Clean up the Docker container after completion.
   -n NAME, --name NAME  Docker image name, default is "fedora". Can write a
                         tag, such as "ubuntu:18.10".
+  -l LINES, --lines LINES
+                        The maximum number of lines to output, default is 100.
+                        Set to 0 or less than 0 means no limit. If --verbose
+                        is enabled, the value is ignored as unlimited.
   -c CONFIG, --config CONFIG
-                        Configuration file path, default is ".docker-
-                        build.yml".
+                        Configuration file path, default is ".docker-build.yml".
   -b {meson,autotools}, --build {meson,autotools}
                         The build type, can be "autotools" or "meson".
 ```
@@ -69,9 +72,9 @@ The dependency package is written in the configuration file in the 2nd step.
 You may see an error, usually because of a lack of dependencies, you can try
 adding it in `.docker-build.yml` and run it again.
 
-If you want to delete the container after it's done, add the clean parameter:
+If you want to delete the container, run the follow command:
 ```
-  docker-build --name ubuntu:18.10 --verbose --clean --build autotools
+  docker-build --name ubuntu:18.10 --clean
 ```
 
 # Configuration file format

--- a/travis/docker-build
+++ b/travis/docker-build
@@ -106,6 +106,13 @@ def load_config (cfgfile):
 
 def run_cmd(command, opts):
     print_cmdline(command)
+    if command.startswith('docker exec'):
+        sh = command.split()[-1].strip()
+        shpath = os.path.join(opts['host_dir'], os.path.basename(sh))
+        if os.path.isfile(shpath):
+            print('# cat %s' % sh)
+            print(open(shpath).read())
+            print('# %s' % sh)
 
     result = Result()
     if opts['verbose']:
@@ -192,8 +199,8 @@ def get_repo_name():
 def build_run(script, cmdline, opts):
     shpath = os.path.join(opts['host_dir'], script)
     fp = open(shpath, 'w+')
-    fp.write('#!/bin/bash\n\n')
-    if args.verbose:
+    fp.write('#!/bin/bash\n')
+    if opts['verbose']:
         fp.write('set -x\n\n')
 
     # Setup envirment variables
@@ -208,9 +215,10 @@ def build_run(script, cmdline, opts):
             continue
         fp.write ("export %s=%s\n" % (k.upper(), str(v).lower()))
 
-    fp.write('cd /rootdir\n')
-    fp.write(' && '.join(cmdline))
     fp.write('\n')
+    fp.write('cd /rootdir\n\n')
+    for line in cmdline:
+        fp.write('%s\n' % line)
     fp.close()
     os.chmod(shpath, stat.S_IRWXU |stat.S_IXGRP|stat.S_IXOTH)
     docker_exec(os.path.join('/rootdir/', script), opts)

--- a/travis/docker-build
+++ b/travis/docker-build
@@ -30,6 +30,37 @@ import subprocess
 class Result:
     pass
 
+class ShortIO(object):
+    def __init__ (self, max_lines=0):
+        self.head_lines = int(max_lines/2)
+        self.tail_lines = int(max_lines - self.head_lines)
+        self.line_count = 0
+        self.tail_list = []
+
+    def print(self, msg):
+        if self.head_lines <= 0 or self.tail_lines <= 0:
+            print(msg, end='', flush=True)
+            return
+        if self.line_count < self.head_lines:
+            print(msg, end='', flush=True)
+        else:
+            print('.', end='', flush=True)
+            self.tail_list.append(msg)
+            if len(self.tail_list) > self.tail_lines:
+                self.tail_list = self.tail_list[self.tail_lines:]
+        self.line_count += 1
+
+    def end(self):
+        if self.head_lines <= 0 or self.tail_lines <= 0:
+            return
+        result = self.line_count - self.head_lines - self.tail_lines
+        if result > 0:
+            print(' Hidden %d lines of output here ......' % result)
+        else:
+            print()
+        for line in self.tail_list:
+            print(line, end='', flush=True)
+
 class bcolors:
     CEND    = '\33[0m'
     CRED    = '\33[31m'
@@ -56,6 +87,7 @@ def parse_args():
     parser.add_argument('-v', '--verbose', dest='verbose', action='store_true', help='Enable verbose output')
     parser.add_argument('-C', '--clean', dest='clean', action='store_true', help='Clean up the Docker container after completion.')
     parser.add_argument('-n', '--name',  dest='name', action='store', default='fedora', help='Docker image name, default is "fedora". Can write a tag, such as "ubuntu:18.10".')
+    parser.add_argument('-l', '--lines',  dest='lines', action='store', type=int, default=100, help='The maximum number of lines to output, default is 100. Set to 0 or less than 0 means no limit. If --verbose is enabled, the value is ignored as unlimited.')
     parser.add_argument('-c', '--config',  dest='config', action='store', default='.docker-build.yml', help='Configuration file path, default is ".docker-build.yml".')
     parser.add_argument('-b', '--build', dest='build', action='store', choices={'autotools','meson'}, help='The build type, can be "autotools" or "meson".')
 
@@ -72,13 +104,18 @@ def load_config (cfgfile):
         fp.close()
     return cfg
 
-def run_cmd(command):
+def run_cmd(command, verbose=True, max_lines=0):
     print_cmdline(command)
 
     result = Result()
+    if verbose:
+        io = ShortIO(-1)
+    else:
+        io = ShortIO(max_lines)
     p = subprocess.Popen(shlex.split(command), stdout=subprocess.PIPE, bufsize=1)
     for line in iter(p.stdout.readline, b''):
-        print(line.decode('utf-8'), end='', flush=True)
+        io.print(line.decode('utf-8'))
+    io.end()
     p.stdout.close()
     p.wait()
 
@@ -99,9 +136,9 @@ def docker_run_daemon (image_name, container_name, cmdline):
     if result.exit_code != 0:
         sys.exit(1)
 
-def docker_exec (container_name, cmdline):
+def docker_exec (container_name, cmdline, verbose=True, max_lines=0):
     cmd = "docker exec -t %s %s" % (container_name, cmdline)
-    result = run_cmd (cmd)
+    result = run_cmd (cmd, verbose, max_lines)
     if result.exit_code != 0:
         sys.exit(1)
 
@@ -135,11 +172,14 @@ def system_update (distro, container_name):
     if len(update_cmd) > 0:
         docker_exec (container_name, update_cmd)
 
-def system_install (distro, container_name):
+def system_install (distro, container_name, verbose=False, max_lines=0):
     if 'requires' not in config.keys():
         return
     if distro in config['requires'].keys():
-        requires = ' '.join(config['requires'][distro])
+        distro_requires = config['requires'][distro]
+        if not distro_requires:
+            return
+        requires = ' '.join(distro_requires)
         if distro == 'archlinux':
             cmd = 'pacman -Sy --noconfirm %s' % requires
         elif distro == 'centos':
@@ -148,7 +188,7 @@ def system_install (distro, container_name):
             cmd = 'dnf install -y %s' % requires
         elif distro == 'debian' or distro == 'ubuntu':
             cmd = 'apt-get install -y %s' % requires
-        docker_exec (container_name, cmd)
+        docker_exec (container_name, cmd, verbose, max_lines)
 
 def get_repo_name():
     cmd = 'git rev-parse --show-toplevel'
@@ -258,12 +298,13 @@ if __name__=="__main__":
         if not docker_is_running (container_name):
             docker_run_daemon(args.name, container_name, '/bin/bash')
         system_update(distro, container_name)
-        system_install(distro, container_name)
+        system_install(distro, container_name, args.verbose, args.lines)
 
     if args.build:
         before_scripts(container_name)
         source_build(args.build, container_name)
         after_scripts(container_name)
-        if args.clean and docker_is_running (container_name):
-            docker_kill (container_name)
-            docker_rm (container_name)
+
+    if args.clean and docker_is_running (container_name):
+        docker_kill (container_name)
+        docker_rm (container_name)

--- a/travis/docker-build
+++ b/travis/docker-build
@@ -250,7 +250,7 @@ def setup_options(args, config):
     elif distro_name == 'centos':
         option['distro_upgrade'] = 'yum update -y'
         option['install_command'] = 'yum install -y'
-    if distro_name == 'fedora':
+    elif distro_name == 'fedora':
         option['distro_upgrade'] = 'dnf update -y'
         option['install_command'] = 'dnf install -y'
     elif distro_name == 'debian' or distro_name == 'ubuntu':

--- a/travis/docker-build
+++ b/travis/docker-build
@@ -190,7 +190,8 @@ def get_repo_name():
     return os.path.basename(output.strip())
 
 def build_run(script, cmdline, opts):
-    fp = open(script, 'w+')
+    shpath = os.path.join(opts['host_dir'], script)
+    fp = open(shpath, 'w+')
     fp.write('#!/bin/bash\n\n')
     if args.verbose:
         fp.write('set -x\n\n')
@@ -211,7 +212,7 @@ def build_run(script, cmdline, opts):
     fp.write(' && '.join(cmdline))
     fp.write('\n')
     fp.close()
-    os.chmod(script, stat.S_IRWXU |stat.S_IXGRP|stat.S_IXOTH)
+    os.chmod(shpath, stat.S_IRWXU |stat.S_IXGRP|stat.S_IXOTH)
     docker_exec(os.path.join('/rootdir/', script), opts)
 
 def setup_options(args, config):

--- a/travis/docker-build
+++ b/travis/docker-build
@@ -133,10 +133,10 @@ def docker_pull (opts):
 
 def docker_run_daemon (command, opts):
     container_name = opts['container_name']
-    start_dir = opts['start_dir']
+    host_dir = opts['host_dir']
     image_name = "%s:%s" % (opts['distro_name'], opts['distro_version'])
 
-    cmd = "docker run --name %s --volume %s:/rootdir -t -d %s %s" % (container_name, start_dir, image_name, command)
+    cmd = "docker run --name %s --volume %s:/rootdir -t -d %s %s" % (container_name, host_dir, image_name, command)
     result = run_cmd (cmd, opts)
     if result.exit_code != 0:
         sys.exit(1)
@@ -203,7 +203,7 @@ def build_run(script, cmdline, opts):
 
     # export option setup as envirment variables
     for k, v in opts.items():
-        if k in ['config', 'distro_upgrade', 'install_command']:
+        if k in ['config', 'distro_upgrade', 'install_command', 'host_dir']:
             continue
         fp.write ("export %s=%s\n" % (k.upper(), str(v).lower()))
 
@@ -220,6 +220,7 @@ def setup_options(args, config):
             'distro_name' : 'fedora',
             'distro_version' : 'latest',
             'max_lines' : args.lines,
+            'host_dir' : os.path.dirname(os.path.abspath(__file__)),
             'start_dir' : '/rootdir',
             'build_dir' : '/rootdir',
             'verbose' : args.verbose,
@@ -266,7 +267,6 @@ def run_scripts(opts, stage = 'before'):
     script_name = stage + '_scripts'
     if script_name not in opts['config'].keys():
         return
-
     build_run (script_name, opts['config'][script_name], opts)
 
 def autotools_build (opts):

--- a/travis/docker-build
+++ b/travis/docker-build
@@ -104,14 +104,14 @@ def load_config (cfgfile):
         fp.close()
     return cfg
 
-def run_cmd(command, verbose=True, max_lines=0):
+def run_cmd(command, opts):
     print_cmdline(command)
 
     result = Result()
-    if verbose:
+    if opts['verbose']:
         io = ShortIO(-1)
     else:
-        io = ShortIO(max_lines)
+        io = ShortIO(opts['max_lines'])
     p = subprocess.Popen(shlex.split(command), stdout=subprocess.PIPE, bufsize=1)
     for line in iter(p.stdout.readline, b''):
         io.print(line.decode('utf-8'))
@@ -124,71 +124,64 @@ def run_cmd(command, verbose=True, max_lines=0):
 
     return result
 
-def docker_pull (image_name):
-    cmd = "docker pull %s" % args.name
-    result = run_cmd (cmd)
+def docker_pull (opts):
+    image_name = "%s:%s" % (opts['distro_name'], opts['distro_version'])
+    cmd = "docker pull %s" % image_name
+    result = run_cmd (cmd, opts)
     if result.exit_code != 0:
         sys.exit(1)
 
-def docker_run_daemon (image_name, container_name, cmdline):
-    cmd = "docker run --name %s --volume %s:/rootdir -t -d %s %s" % (container_name, os.getcwd(), image_name, cmdline)
-    result = run_cmd (cmd)
+def docker_run_daemon (command, opts):
+    container_name = opts['container_name']
+    start_dir = opts['start_dir']
+    image_name = "%s:%s" % (opts['distro_name'], opts['distro_version'])
+
+    cmd = "docker run --name %s --volume %s:/rootdir -t -d %s %s" % (container_name, start_dir, image_name, command)
+    result = run_cmd (cmd, opts)
     if result.exit_code != 0:
         sys.exit(1)
 
-def docker_exec (container_name, cmdline, verbose=True, max_lines=0):
-    cmd = "docker exec -t %s %s" % (container_name, cmdline)
-    result = run_cmd (cmd, verbose, max_lines)
+def docker_exec (command, opts):
+    container_name = opts['container_name']
+    cmd = "docker exec -t %s %s" % (container_name, command)
+    result = run_cmd (cmd, opts)
     if result.exit_code != 0:
         sys.exit(1)
 
-def docker_is_running (container_name):
-    cmd = "docker inspect -f '{{.State.Running}}' %s" % container_name
-    result = run_cmd (cmd)
+def docker_is_running (opts):
+    cmd = "docker inspect -f '{{.State.Running}}' %s" % opts['container_name']
+    result = run_cmd (cmd, opts)
     return result.exit_code == 0
 
-def docker_kill (container_name):
-    cmd = "docker container kill %s" % container_name
-    result = run_cmd (cmd)
+def docker_kill (opts):
+    cmd = "docker container kill %s" % opts['container_name']
+    result = run_cmd (cmd, opts)
     if result.exit_code != 0:
         sys.exit(1)
 
-def docker_rm (container_name):
-    cmd = "docker container rm %s" % container_name
-    result = run_cmd (cmd)
+def docker_rm (opts):
+    cmd = "docker container rm %s" % opts['container_name']
+    result = run_cmd (cmd, opts)
     if result.exit_code != 0:
         sys.exit(1)
 
-def system_update (distro, container_name):
-    update_cmd = ''
-    if distro == 'archlinux':
-        update_cmd = 'pacman -Syu --noconfirm'
-    elif distro == 'centos':
-        update_cmd = 'yum update -y'
-    if distro == 'fedora':
-        update_cmd = 'dnf update -y'
-    elif distro == 'debian' or distro == 'ubuntu':
-        update_cmd = 'apt-get update -y'
-    if len(update_cmd) > 0:
-        docker_exec (container_name, update_cmd)
+# The follow commands running in the docker.
+def system_update (opts):
+    docker_exec (opts['distro_upgrade'], opts)
 
-def system_install (distro, container_name, verbose=False, max_lines=0):
-    if 'requires' not in config.keys():
+def system_install (opts):
+    if 'requires' not in opts['config'].keys():
         return
-    if distro in config['requires'].keys():
-        distro_requires = config['requires'][distro]
-        if not distro_requires:
-            return
-        requires = ' '.join(distro_requires)
-        if distro == 'archlinux':
-            cmd = 'pacman -Sy --noconfirm %s' % requires
-        elif distro == 'centos':
-            cmd = 'yum install -y %s' % requires
-        if distro == 'fedora':
-            cmd = 'dnf install -y %s' % requires
-        elif distro == 'debian' or distro == 'ubuntu':
-            cmd = 'apt-get install -y %s' % requires
-        docker_exec (container_name, cmd, verbose, max_lines)
+
+    distro_name = opts['distro_name']
+    if distro_name in opts['config']['requires'].keys():
+        distro_requires = opts['config']['requires'][distro_name]
+        if distro_requires:
+            requires = ' '.join(distro_requires)
+        else:
+            requires = 'gcc git make'
+        cmd = '%s %s' % (opts['install_command'], requires)
+        docker_exec (cmd, opts)
 
 def get_repo_name():
     cmd = 'git rev-parse --show-toplevel'
@@ -196,46 +189,90 @@ def get_repo_name():
     output = output.decode("utf-8")
     return os.path.basename(output.strip())
 
-def build_run (container_name, shfile, cmdlines, variables=[]):
-    fp = open(shfile, 'w+')
+def build_run(script, cmdline, opts):
+    fp = open(script, 'w+')
     fp.write('#!/bin/bash\n\n')
     if args.verbose:
         fp.write('set -x\n\n')
-    for var in variables:
-        if var.find('=') > 0:
-            fp.write ("export %s\n" % var)
+
+    # Setup envirment variables
+    if 'variables' in opts['config'].keys():
+        for var in opts['config']['variables']:
+            if var.find('=') > 0:
+                fp.write ("export %s\n" % var)
+
+    # export option setup as envirment variables
+    for k, v in opts.items():
+        if k in ['config', 'distro_upgrade', 'install_command']:
+            continue
+        fp.write ("export %s=%s\n" % (k.upper(), str(v).lower()))
+
     fp.write('cd /rootdir\n')
-    fp.write(' && '.join(cmdlines))
+    fp.write(' && '.join(cmdline))
     fp.write('\n')
     fp.close()
-    os.chmod(shfile, stat.S_IRWXU |stat.S_IXGRP|stat.S_IXOTH)
-    docker_exec (container_name, os.path.join('/rootdir/', shfile))
+    os.chmod(script, stat.S_IRWXU |stat.S_IXGRP|stat.S_IXOTH)
+    docker_exec(os.path.join('/rootdir/', script), opts)
 
-def before_scripts(container_name):
-    if 'before_scripts' not in config.keys():
+def setup_options(args, config):
+    option = {
+            'build_type' : 'autotools',
+            'distro_name' : 'fedora',
+            'distro_version' : 'latest',
+            'max_lines' : args.lines,
+            'start_dir' : '/rootdir',
+            'build_dir' : '/rootdir',
+            'verbose' : args.verbose,
+            'config' : config,
+            }
+
+    # parse distro
+    distro = args.name.split(':')
+    distro_name = distro[0]
+    if distro_name.find('/') > 0:
+        distro_name = distro_name.rsplit('/',1)[-1]
+
+    option['distro_name'] = distro_name
+    option['container_name'] = "%s-%s-build" % (get_repo_name(), option['distro_name'])
+    if distro_name == 'archlinux':
+        option['distro_upgrade'] = 'pacman -Syu --noconfirm'
+        option['install_command'] = 'pacman -Sy --noconfirm'
+    elif distro_name == 'centos':
+        option['distro_upgrade'] = 'yum update -y'
+        option['install_command'] = 'yum install -y'
+    if distro_name == 'fedora':
+        option['distro_upgrade'] = 'dnf update -y'
+        option['install_command'] = 'dnf install -y'
+    elif distro_name == 'debian' or distro_name == 'ubuntu':
+        option['distro_upgrade'] = 'apt-get update -y'
+        option['install_command'] = 'apt-get install -y'
+    else:
+        url = 'https://github.com/mate-desktop/mate-dev-scripts/issues/new'
+        msg = 'The "%s" distro is not supported, please visit "%s" to create a new issue.' % (distro_name, url)
+        print_error(msg)
+        sys.exit(1)
+
+    if len(distro) > 1:
+        option['distro_version'] = distro[-1]
+
+    if args.build == 'meson':
+        option['build_type'] = 'meson'
+        option['build_dir'] = os.path.join(option['start_dir'], '_build')
+
+    return option
+
+# Run in docker
+def run_scripts(opts, stage = 'before'):
+    script_name = stage + '_scripts'
+    if script_name not in opts['config'].keys():
         return
 
-    env = ['BUILD_TYPE=autotools']
-    if args.build == 'meson':
-        env = ['BUILD_TYPE=meson']
+    build_run (script_name, opts['config'][script_name], opts)
 
-    build_run (container_name, 'before_scripts', config['before_scripts'], env)
-
-def after_scripts(container_name):
-    if 'after_scripts' not in config.keys():
-        return
-
-    env = ['BUILD_TYPE=autotools']
-    if args.build == 'meson':
-        config['after_scripts'].insert(0, "cd _build")
-        env = ['BUILD_TYPE=meson']
-
-    build_run (container_name, 'after_scripts', config['after_scripts'], env)
-
-def autotools_build (container_name):
+def autotools_build (opts):
     configures = '--prefix=/usr'
-    if 'configures' in config.keys() and 'autotools' in config['configures'].keys():
-        configures = ' '.join(config['configures']['autotools'])
+    if 'configures' in opts['config'].keys() and 'autotools' in opts['config']['configures'].keys():
+        configures = ' '.join(opts['config']['configures']['autotools'])
 
     cmdlines = []
     if os.path.isfile('./autogen.sh'):
@@ -245,31 +282,25 @@ def autotools_build (container_name):
 
     if os.path.isfile('./autogen.sh') or os.path.isfile('./configure'):
         cmdlines.append('make')
-        if 'variables' in config.keys():
-            build_run (container_name, 'src_build', cmdlines, config['variables'])
-        else:
-            build_run (container_name, 'src_build', cmdlines)
+        build_run ('src_build', cmdlines, opts)
 
-def meson_build (container_name):
+def meson_build (opts):
     configures = '--prefix /usr'
-    if 'configures' in config.keys() and 'meson' in config['configures'].keys():
-        configures = ' '.join(config['configures']['meson'])
+    if 'configures' in opts['config'].keys() and 'meson' in opts['config']['configures'].keys():
+        configures = ' '.join(opts['config']['configures']['meson'])
 
     cmdlines = []
     if os.path.isfile('./meson.build'):
         cmdlines.append('meson _build ' + configures)
         cmdlines.append('cd _build')
         cmdlines.append('ninja')
-        if 'variables' in config.keys():
-            build_run (container_name, 'src_build', cmdlines, config['variables'])
-        else:
-            build_run (container_name, 'src_build', cmdlines)
+        build_run ('src_build', cmdlines, opts)
 
-def source_build(build_type, container_name):
-    if build_type == "autotools":
-        autotools_build (container_name)
-    elif build_type == "meson":
-        meson_build (container_name)
+def source_build(opts):
+    if opts['build_type'] == 'autotools':
+        autotools_build (opts)
+    elif opts['build_type'] == 'meson':
+        meson_build (opts)
 
 if __name__=="__main__":
     args = parse_args()
@@ -278,33 +309,30 @@ if __name__=="__main__":
         try:
             import yaml
         except:
-            run_cmd ("apt-get update -y")
-            run_cmd ("apt-get install -y python3-yaml")
+            run_cmd ("apt-get update -y", {'verbose':True, 'max_lines':100})
+            run_cmd ("apt-get install -y python3-yaml", {'verbose':True, 'max_lines':100})
             try:
                 import yaml
             except:
-                print_error("Don't use '%s' as config file\n" % args.config)
+                msg = "Can't import 'yaml' python module on the Host OS.\nPlease replace the '%s' file with a JSON file.\n" % args.config
+                print_error(msg)
                 sys.exit(1)
 
     config = load_config(args.config)
-
-    distro = args.name.split(':')[0]
-    if distro.find('/') > 0:
-        distro = distro.rsplit('/',1)[-1]
-    container_name = "%s-%s-build" % (get_repo_name(), distro)
+    opts = setup_options(args, config)
 
     if args.install:
-        docker_pull(args.name)
-        if not docker_is_running (container_name):
-            docker_run_daemon(args.name, container_name, '/bin/bash')
-        system_update(distro, container_name)
-        system_install(distro, container_name, args.verbose, args.lines)
+        docker_pull(opts)
+        if not docker_is_running (opts):
+            docker_run_daemon('/bin/bash', opts)
+        system_update(opts)
+        system_install(opts)
 
     if args.build:
-        before_scripts(container_name)
-        source_build(args.build, container_name)
-        after_scripts(container_name)
+        run_scripts(opts, 'before')
+        source_build(opts)
+        run_scripts(opts, 'after')
 
-    if args.clean and docker_is_running (container_name):
-        docker_kill (container_name)
-        docker_rm (container_name)
+    if args.clean and docker_is_running (opts):
+        docker_kill (opts)
+        docker_rm (opts)


### PR DESCRIPTION
The Travis CI website has a limit of [10,000](https://travis-ci.org/mate-desktop/caja/jobs/487409953#L10000) lines of output.

If there are too many installation dependencies, you will not see the full build log.

Before, build start at line 2092:
https://travis-ci.org/mate-desktop/caja/jobs/487409954#L2092
After, build start at line 533:
https://travis-ci.org/yetist/caja/jobs/487442500#L533