### PR TITLE
travis: docker-build: list versions of the required packages installed

### DIFF
--- a/travis/docker-build
+++ b/travis/docker-build
@@ -667,6 +667,13 @@ def system_install (opts):
             requires = 'gcc git make'
         cmd = '%s %s' % (opts['install_command'], requires)
         docker_exec (cmd, opts)
+        # list versions of the required packages installed
+        if distro_name == 'debian' or distro_name == 'ubuntu':
+            docker_exec ("apt list --installed %s" % requires, opts)
+        if distro_name == 'archlinux':
+            docker_exec ("pacman -Q %s" % requires, opts)
+        if distro_name == 'fedora':
+            docker_exec ("rpm -qa %s" % requires, opts)
 
 def get_repo_name(join_char=None):
     cmd = 'git remote get-url origin'


### PR DESCRIPTION
tested here:

https://travis-ci.org/mate-desktop/engrampa/builds/599067809

debian build:

![2019-10-18_02-17](https://user-images.githubusercontent.com/7734191/67056711-7ccb8800-f14d-11e9-931f-72a33a8b0821.png)

fedora builds always fails, not related to this PR.

Closes https://github.com/mate-desktop/mate-dev-scripts/issues/28