### PR TITLE
Fix getting remote Git URL for cloning gh-pages

### DIFF
--- a/travis/gen-index.sh
+++ b/travis/gen-index.sh
@@ -154,7 +154,7 @@ fi
 
 # add the history results
 temp_work_dir=`mktemp -d -u`
-remote_url=`git config remote.origin.url`
+remote_url=`git config remote.origin.url` || remote_url="https://github.com/${owner}/${name}.git"
 
 git clone --single-branch  --branch=gh-pages ${remote_url} ${temp_work_dir}
 rm -f ${temp_work_dir}/${index_page} ${temp_work_dir}/CNAME


### PR DESCRIPTION
Apparently we don't get `remote.origin.url` from Git anymore for some reason, so fallback on a HTTPS URL built from known pieces.

Not tested yet, not sure how to do so before actually committing…