### PR TITLE
fix travis-Ci build against newer glibc

### DIFF
--- a/travis/docker-build
+++ b/travis/docker-build
@@ -598,7 +598,7 @@ def docker_run_daemon (command, opts):
     image_name = opts['image_name']
     opts['stage'] = 'docker_run_daemon'
 
-    cmd = "docker run --name %s --volume %s:%s -t -d %s %s" % (container_name, host_dir, ROOT_DIR, image_name, command)
+    cmd = "docker run --security-opt seccomp=unconfined --name %s --volume %s:%s -t -d %s %s" % (container_name, host_dir, ROOT_DIR, image_name, command)
     result = run_cmd (cmd, opts)
     if result.exit_code != 0:
         sys.exit(1)


### PR DESCRIPTION
This will fix issues with debian=testing and upcoming fedora 37 travis builds.
Build errors are caused by an glibc update
https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2435
and an update to docker policy `seccomp` 
https://github.com/moby/moby/pull/42681/commits/9f6b562dd12ef7b1f9e2f8e6f2ab6477790a6594
More details you will find here:
https://gist.github.com/nathabonfim59/b088db8752673e1e7acace8806390242

Note, using `docker run --security-opt seccomp=unconfined .....` is a workaround, `seccomp=unconfined` means not to use a policy.
So, the real fix might be done in the code of our packages.
Not sure if package which use meson are affected too.