### PR TITLE
Add script to convert help document from docbook to mallard pages

### DIFF
--- a/maintainer/docbook2mallard
+++ b/maintainer/docbook2mallard
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <docbook>"
+  echo
+  echo "Example:"
+  echo "$0 help/C/index.docbook"
+  exit
+fi
+
+realpath=`realpath $1`
+docdir=`dirname $1`
+
+if [ ! -f /tmp/db2mal/db2mal.xsl ]; then
+  git clone https://github.com/projectmallard/db2mal.git /tmp/db2mal
+fi
+
+cd $docdir
+xsltproc /tmp//db2mal/db2mal.xsl $realpath
+
+for i in *.page; do
+  xmllint --pretty 1 $i > ${i}.new
+  mv ${i}.new ${i}
+done


### PR DESCRIPTION
Many of Mate's applications use DocBook. To be honest, this is so complicated that no one wants to touch it, and it has not been updated and maintained in time.

[Mallard](http://projectmallard.org/about/index.html) use a simplified version of DocBook to write help documents, [Mallard 1.1 specification](http://projectmallard.org/1.1/index.html) was marked final on 2019-01-29, it is time to convert docbook to mallard page.

This helper script can automatically convert DocBook to multiple page files in Mallard format, which can be used as the basis for manual modification later, which can save a lot of time.

Usage: 
```
docbook2mallard mate-terminal/help/C/index.docbook
```
Many `.page` files are now available in the `mate-terminal/help/C` directory.